### PR TITLE
FIN-3416 fork of granule/data-bind internal usage preparations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-    "name": "granule/data-bind",
-    "description": "Granule Data Bind Component",
+    "name": "dealroadshow/granule-data-bind",
+    "description": "Granule Data Bind Component fork",
     "type": "library",
     "require": {
         "php": "^7.1",
         "ext-yaml": "^2.0",
-        "granule/util": "^0.3.0"
+        "dealroadshow/granule-util": "^0.3.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^6"


### PR DESCRIPTION
ISSUES RESOLVED
------
https://finsight.myjetbrains.com/youtrack/issue/FIN-3416

DESCRIPTION
--
Providing the ability to internal require and use of forked package with new name [dealroadshow/granule-data-bind](https://github.com/dealroadshow/data-bind) instead of [granule/data-bind](https://github.com/granulephp/data-bind)

QA
--
WhiteList and BlackList add/edit functionality for Roadshow should work as usual. 
There is also happened the replacement of some code libraries source from external to internal, while the code remains the same. Please keep in mind this fact just in case.
