### PR TITLE
FIN-14563 - Change type of ClassExtractor::$object

### DIFF
--- a/lib/Extractor/ClassExtractor.php
+++ b/lib/Extractor/ClassExtractor.php
@@ -31,7 +31,7 @@ use Granule\DataBind\Type;
 class ClassExtractor extends BasicExtractor
 {
     private DependencyResolver $resolver;
-    private object $object;
+    private object|bool|int|string|array $object;
 
     public function __construct(DependencyResolver $resolver, $object)
     {


### PR DESCRIPTION
ISSUES RESOLVED
-------
https://finsight.myjetbrains.com/youtrack/issue/FIN-14563

DESCRIPTION
-------
Query responses can be scalar or array
```
Cannot assign bool to property Granule\DataBind\Extractor\ClassExtractor::$object of type object 
{"cause":"Platform\\Contract\\Finsight\\Domain\\Roadshow\\API\\IsPlatformBlacklistedQuery","error":"[object] 
(TypeError(code: 0): Cannot assign bool to property Granule\\DataBind\\Extractor\\ClassExtractor::$object 
of type object at /data/finsight-core/vendor/dealroadshow/granule-data-bind/lib/Extractor/ClassExtractor.php:39)
```

