### PR TITLE
[FIN-16815] fix nullable properties unserialization

### DIFF
--- a/lib/Serializer/POCOSerializer.php
+++ b/lib/Serializer/POCOSerializer.php
@@ -143,7 +143,7 @@ class POCOSerializer extends Serializer implements DependencyResolverAware
 
             if (!array_key_exists($key, $data) || $data[$key] === null) {
                 if ($type->isNullable()) {
-                    continue;
+                    $property->setValue($object, null);
                 } else {
                     throw NullValueException::fromPropertyWithType($property, $type);
                 }

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -88,6 +88,7 @@ class ConverterTest extends TestCase
                     'layer' => ['name' => 'the one'],
                     'birthdate' => 'Friday, 20-Jul-84 00:00:00 UTC',
                     'nativeEnum' => ['name' => 'One'],
+                    'strictTypedNullableString' => null,
                 ],
                 TestObject::class
             ]
@@ -227,7 +228,18 @@ class ConverterTest extends TestCase
                     return $value;
                 },
                 TestNativeEnum::One
-            ]
+            ],
+            'strictTypedNullableString' => [
+                $fixture,
+                'strictTypedNullableString',
+                function ($value) {
+                    return is_null($value);
+                },
+                function ($value) {
+                    return $value;
+                },
+                null
+            ],
         ];
     }
 

--- a/tests/_fixtures/TestObject.php
+++ b/tests/_fixtures/TestObject.php
@@ -63,6 +63,7 @@ class TestObject
     /** @var TestEnum */
     private $question;
     private TestNativeEnum $nativeEnum;
+    private ?string $strictTypedNullableString;
 
     public function getLayer(): TestInternalObject
     {


### PR DESCRIPTION
ISSUES RESOLVED
-------
https://finsight.myjetbrains.com/youtrack/issue/FIN-16815

DESCRIPTION
-------
This fix allows us to use new php syntax to initialize properties (called "promoted properties") in our commands/queries since before it there were errors like "Typed property must not be accessed before initialization" for nullable properties with no value passed. Also, it allows us to not duplicate the default value in a class itself when it receives value from a builder.

Example:
`public function __construct(private ?string $name = null) {}`
Without this fix, trying to get the `$name` value after object unserialization will result in the error described above.

